### PR TITLE
show the vue-version for this plugin...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # vue-notifyjs
-Minimalist notification component for Vue
+Minimalist notification component for Vue 2.x
 
 Why use it?
 - Small: 1kb (minified & gzipped), 3kb (minified)


### PR DESCRIPTION
this project is based on vue2. Since there exist a huge difference in vue1 & vue2 it's common sense to show the vue version in the project name or in the first line of the readme like here: https://github.com/xkjyeah/vue-google-maps.