### PR TITLE
Update README.md (Add `Primary` type)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ props: {
     },
     type: {
       type: String,
-      default: 'info' // info | warning | danger | success
+      default: 'info' // info | warning | danger | success | primary
     },
     timeout: {
       type: Number,


### PR DESCRIPTION
caused a confusion that the examples have the `primary` type but it's not mentioned in the single place in the readme that listed all possible types.

Thank you for this project :+1:  .. simplest solution I found for notifications integrated with vue.