### PR TITLE
Passing component (without the need of the vue compiler) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,23 @@ props: {
   clickHandler: Function,
 },
 ```
+## Passing component (without the need of the vue compiler)
+
+In production mode, you probably don't want to ship your app with the vue compiler. To accomplish this, your need to pass your component within the render function.
+
+```
+component: {
+  render (createElement) {
+    return createElement(
+      'span',
+      [ createElement('b', {}, msg) ]
+    );
+  }
+}
+```
+
+This is equivalent to <span><b>{{ msg }}</b></span>
+
 ## Methods
 
 clear() - Clears all current notifications

--- a/README.md
+++ b/README.md
@@ -176,8 +176,6 @@ component: {
 }
 ```
 
-This is equivalent to <span><b>{{ msg }}</b></span>
-
 ## Methods
 
 clear() - Clears all current notifications


### PR DESCRIPTION
I found readme file not so much explicit regarding the use of component instead of message. And because I don't ship the vue compiler anymore with my app, using render function is essential.